### PR TITLE
doc: remove manual pip package install since it's installed by greengrass

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ This steps assume you have an SD Card and Raspberry PI
    1. Start your Raspberry Pi with SD Card plugged in it
    1. SSH to it by connecting your PC to the network you set up in the previous steps (`ssh pi@raspberrypi.local`)
 1. Install the missing dependencies:
-   1. Install Java, pip3 and awscert using apt
+   1. Install Java and pip3 using apt
       ```
       sudo apt-get install default-jre python3-pip
-      pip3 install awscert
       ```
    1. Install Greengrass running the following command
       ```


### PR DESCRIPTION
Fixing typo  on a pip package install instruction`awscert` by removing it from the instruction since greengrass will already take care of installing the right one `awscrt` through one of the recipe (https://github.com/aws-samples/water-tank-digital-twin/blob/58df5e74b171ecff2b0be27f9b72d5058dace64f/lib/iot/src/timestream_sync/requirements.txt#L3).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
